### PR TITLE
feat:１分周期で同期時刻を修正

### DIFF
--- a/src/components/SyncButton.tsx
+++ b/src/components/SyncButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Icon } from "./Icon";
 
 interface SyncButtonProps {
@@ -26,6 +27,18 @@ function formatLastSync(date: Date): string {
 }
 
 export function SyncButton({ onSync, loading, lastSync }: SyncButtonProps) {
+  const [, forceUpdate] = useState({});
+
+  useEffect(() => {
+    // 1分ごとにコンポーネントを強制再レンダリングして最終同期時刻を更新
+    const timer = setInterval(() => {
+      forceUpdate({});
+    }, 60000); // 60秒 = 60000ミリ秒
+
+    // コンポーネントのクリーンアップ時にタイマーを削除
+    return () => clearInterval(timer);
+  }, []);
+
   return (
     <div className="flex items-center space-x-4">
       {lastSync && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - SyncButton の「最終同期」表示が、操作やプロパティ変更がなくても60秒ごとに自動更新されるようになりました。
  - これにより、表示の古さや更新漏れが減り、同期時刻の最新性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->