### PR TITLE
feat: カラーテーマ追加

### DIFF
--- a/src/app/_components/ThemeSelect.tsx
+++ b/src/app/_components/ThemeSelect.tsx
@@ -9,29 +9,27 @@ const THEME_LABELS: Record<ThemeKey, string> = {
   white: "ホワイト",
 };
 
-export function ThemeSelect() {
-  const [currentTheme, setCurrentTheme] = useState<ThemeKey>("black");
+// theme-colorメタタグを更新するヘルパー関数
+function updateThemeColorMeta() {
+  const bgColor = getComputedStyle(document.documentElement)
+    .getPropertyValue("--background")
+    .trim();
+  const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+  if (metaThemeColor) {
+    metaThemeColor.setAttribute("content", `hsl(${bgColor})`);
+  }
+}
+
+interface ThemeSelectProps {
+  initialTheme: ThemeKey;
+}
+
+export function ThemeSelect({ initialTheme }: ThemeSelectProps) {
+  const [currentTheme, setCurrentTheme] = useState<ThemeKey>(initialTheme);
 
   useEffect(() => {
-    // 初期値をHTMLのdata-theme属性から取得
-    const theme = document.documentElement.getAttribute(
-      "data-theme",
-    ) as ThemeKey;
-    if (theme && THEMES.includes(theme)) {
-      setCurrentTheme(theme);
-    }
-
-    // theme-colorメタタグを更新
-    const updateThemeColor = () => {
-      const bgColor = getComputedStyle(document.documentElement)
-        .getPropertyValue("--background")
-        .trim();
-      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-      if (metaThemeColor) {
-        metaThemeColor.setAttribute("content", `hsl(${bgColor})`);
-      }
-    };
-    updateThemeColor();
+    // 初回マウント時にtheme-colorメタタグを更新
+    updateThemeColorMeta();
   }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -43,13 +41,7 @@ export function ThemeSelect() {
 
     // theme-colorメタタグを更新
     setTimeout(() => {
-      const bgColor = getComputedStyle(document.documentElement)
-        .getPropertyValue("--background")
-        .trim();
-      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-      if (metaThemeColor) {
-        metaThemeColor.setAttribute("content", `hsl(${bgColor})`);
-      }
+      updateThemeColorMeta();
     }, 0);
 
     // サーバーアクションでCookie永続化

--- a/src/app/_components/ThemeSelect.tsx
+++ b/src/app/_components/ThemeSelect.tsx
@@ -9,12 +9,8 @@ const THEME_LABELS: Record<ThemeKey, string> = {
   white: "ホワイト",
 };
 
-interface ThemeSelectProps {
-  initialTheme: ThemeKey;
-}
-
-export function ThemeSelect({ initialTheme }: ThemeSelectProps) {
-  const [currentTheme, setCurrentTheme] = useState<ThemeKey>(initialTheme);
+export function ThemeSelect() {
+  const [currentTheme, setCurrentTheme] = useState<ThemeKey>("black");
 
   useEffect(() => {
     // 初期値をHTMLのdata-theme属性から取得

--- a/src/app/_components/ThemeSelect.tsx
+++ b/src/app/_components/ThemeSelect.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { startTransition, useEffect, useState } from "react";
+import { setTheme } from "@/app/actions/setTheme";
+import { THEMES, type ThemeKey } from "@/app/actions/theme.types";
+
+const THEME_LABELS: Record<ThemeKey, string> = {
+  black: "ブラック",
+  white: "ホワイト",
+};
+
+export function ThemeSelect() {
+  const [currentTheme, setCurrentTheme] = useState<ThemeKey>("black");
+
+  useEffect(() => {
+    // 初期値をHTMLのdata-theme属性から取得
+    const theme = document.documentElement.getAttribute(
+      "data-theme",
+    ) as ThemeKey;
+    if (theme && THEMES.includes(theme)) {
+      setCurrentTheme(theme);
+    }
+
+    // theme-colorメタタグを更新
+    const updateThemeColor = () => {
+      const bgColor = getComputedStyle(document.documentElement)
+        .getPropertyValue("--background")
+        .trim();
+      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+      if (metaThemeColor) {
+        metaThemeColor.setAttribute("content", `hsl(${bgColor})`);
+      }
+    };
+    updateThemeColor();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTheme = e.target.value as ThemeKey;
+
+    // 即座にDOM更新（UX向上）
+    document.documentElement.setAttribute("data-theme", newTheme);
+    setCurrentTheme(newTheme);
+
+    // theme-colorメタタグを更新
+    setTimeout(() => {
+      const bgColor = getComputedStyle(document.documentElement)
+        .getPropertyValue("--background")
+        .trim();
+      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+      if (metaThemeColor) {
+        metaThemeColor.setAttribute("content", `hsl(${bgColor})`);
+      }
+    }, 0);
+
+    // サーバーアクションでCookie永続化
+    startTransition(() => {
+      setTheme(newTheme).catch((error) => {
+        console.error("テーマの保存に失敗しました:", error);
+      });
+    });
+  };
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <label htmlFor="theme-select" className="text-sm font-medium">
+        テーマ:
+      </label>
+      <select
+        id="theme-select"
+        value={currentTheme}
+        onChange={handleChange}
+        className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground transition-colors hover:opacity-80 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+      >
+        {THEMES.map((theme) => (
+          <option key={theme} value={theme}>
+            {THEME_LABELS[theme]}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/app/_components/ThemeSelect.tsx
+++ b/src/app/_components/ThemeSelect.tsx
@@ -9,8 +9,12 @@ const THEME_LABELS: Record<ThemeKey, string> = {
   white: "ホワイト",
 };
 
-export function ThemeSelect() {
-  const [currentTheme, setCurrentTheme] = useState<ThemeKey>("black");
+interface ThemeSelectProps {
+  initialTheme: ThemeKey;
+}
+
+export function ThemeSelect({ initialTheme }: ThemeSelectProps) {
+  const [currentTheme, setCurrentTheme] = useState<ThemeKey>(initialTheme);
 
   useEffect(() => {
     // 初期値をHTMLのdata-theme属性から取得

--- a/src/app/actions/setTheme.ts
+++ b/src/app/actions/setTheme.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { THEMES, type ThemeKey } from "./theme.types";
+
+/**
+ * テーマをCookieに保存するサーバーアクション
+ * ホワイトリスト検証を実施
+ */
+export async function setTheme(theme: string) {
+  // ホワイトリスト検証
+  if (!THEMES.includes(theme as ThemeKey)) {
+    throw new Error(
+      `Invalid theme: ${theme}. Must be one of: ${THEMES.join(", ")}`,
+    );
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set("theme", theme, {
+    path: "/",
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 60 * 24 * 365, // 1年間
+  });
+
+  return { ok: true };
+}

--- a/src/app/actions/theme.types.ts
+++ b/src/app/actions/theme.types.ts
@@ -1,0 +1,2 @@
+export const THEMES = ["black", "white"] as const;
+export type ThemeKey = (typeof THEMES)[number];

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,35 @@
 @import "tailwindcss";
 
+/* テーマカラー定義 - HSL形式（数値のみ） */
 :root {
-  --background: #0d1117;
-  --foreground: #f0f6fc;
+  /* デフォルト: black */
+  --background: 0 0% 7%;
+  --foreground: 0 0% 98%;
+  --primary: 0 0% 20%;
+  --primary-foreground: 0 0% 98%;
+  --border: 0 0% 15%;
+  --card: 0 0% 10%;
+  --card-foreground: 0 0% 95%;
+}
+
+[data-theme="white"] {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 10%;
+  --primary: 0 0% 90%;
+  --primary-foreground: 0 0% 10%;
+  --border: 0 0% 90%;
+  --card: 0 0% 98%;
+  --card-foreground: 0 0% 15%;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-border: hsl(var(--border));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
   --font-sans:
     var(--font-inter), var(--font-noto-sans-jp), system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -15,8 +37,8 @@
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
   font-family:
     var(--font-inter), var(--font-noto-sans-jp), system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist_Mono, Inter, Noto_Sans_JP } from "next/font/google";
+import { cookies } from "next/headers";
+import { THEMES, type ThemeKey } from "@/app/actions/theme.types";
 import "./globals.css";
 
 const inter = Inter({
@@ -23,18 +25,26 @@ export const metadata: Metadata = {
   description: "Linear issues displayed in Gantt chart format",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get("theme")?.value;
+  const theme: ThemeKey =
+    themeCookie && THEMES.includes(themeCookie as ThemeKey)
+      ? (themeCookie as ThemeKey)
+      : "black";
+
   return (
-    <html lang="ja">
+    <html lang="ja" data-theme={theme} suppressHydrationWarning>
       <head>
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
         />
+        <meta name="theme-color" content="hsl(var(--background))" />
       </head>
       <body
         className={`${inter.variable} ${notoSansJP.variable} ${geistMono.variable} antialiased`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
+import { cookies } from "next/headers";
 import { ThemeSelect } from "@/app/_components/ThemeSelect";
+import { THEMES, type ThemeKey } from "@/app/actions/theme.types";
 import { LinearWorkspace } from "@/components/LinearWorkspace";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import {
@@ -14,6 +16,14 @@ import {
 } from "@/lib/actions";
 
 export default async function Home() {
+  // Cookieからテーマを取得
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get("theme")?.value;
+  const theme: ThemeKey =
+    themeCookie && THEMES.includes(themeCookie as ThemeKey)
+      ? (themeCookie as ThemeKey)
+      : "black";
+
   let issues: LinearIssue[];
   let cycles: LinearCycle[];
   let users: LinearUser[];
@@ -85,7 +95,7 @@ export default async function Home() {
             <h1 className="text-xl font-semibold flex items-center space-x-2">
               <span>Linear Gantt</span>
             </h1>
-            <ThemeSelect />
+            <ThemeSelect initialTheme={theme} />
           </div>
         </div>
       </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,5 @@
 import { Suspense } from "react";
-import { cookies } from "next/headers";
 import { ThemeSelect } from "@/app/_components/ThemeSelect";
-import { THEMES, type ThemeKey } from "@/app/actions/theme.types";
-import { Icon } from "@/components/Icon";
 import { LinearWorkspace } from "@/components/LinearWorkspace";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import {
@@ -17,12 +14,6 @@ import {
 } from "@/lib/actions";
 
 export default async function Home() {
-  const cookieStore = await cookies();
-  const themeCookie = cookieStore.get("theme")?.value;
-  const theme: ThemeKey =
-    themeCookie && THEMES.includes(themeCookie as ThemeKey)
-      ? (themeCookie as ThemeKey)
-      : "black";
   let issues: LinearIssue[];
   let cycles: LinearCycle[];
   let users: LinearUser[];
@@ -94,7 +85,7 @@ export default async function Home() {
             <h1 className="text-xl font-semibold flex items-center space-x-2">
               <span>Linear Gantt</span>
             </h1>
-            <ThemeSelect initialTheme={theme} />
+            <ThemeSelect />
           </div>
         </div>
       </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
+import { cookies } from "next/headers";
 import { ThemeSelect } from "@/app/_components/ThemeSelect";
+import { THEMES, type ThemeKey } from "@/app/actions/theme.types";
 import { Icon } from "@/components/Icon";
 import { LinearWorkspace } from "@/components/LinearWorkspace";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
@@ -15,6 +17,12 @@ import {
 } from "@/lib/actions";
 
 export default async function Home() {
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get("theme")?.value;
+  const theme: ThemeKey =
+    themeCookie && THEMES.includes(themeCookie as ThemeKey)
+      ? (themeCookie as ThemeKey)
+      : "black";
   let issues: LinearIssue[];
   let cycles: LinearCycle[];
   let users: LinearUser[];
@@ -86,7 +94,7 @@ export default async function Home() {
             <h1 className="text-xl font-semibold flex items-center space-x-2">
               <span>Linear Gantt</span>
             </h1>
-            <ThemeSelect />
+            <ThemeSelect initialTheme={theme} />
           </div>
         </div>
       </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { ThemeSelect } from "@/app/_components/ThemeSelect";
 import { Icon } from "@/components/Icon";
 import { LinearWorkspace } from "@/components/LinearWorkspace";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
@@ -59,14 +60,14 @@ export default async function Home() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-[#0d1117] text-white flex items-center justify-center">
+      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
         <div className="text-center">
           <h2 className="text-xl font-semibold mb-2">エラーが発生しました</h2>
-          <p className="text-gray-400 mb-4">{error}</p>
+          <p className="opacity-60 mb-4">{error}</p>
           <form action="">
             <button
               type="submit"
-              className="px-4 py-2 bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors"
+              className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:opacity-80 transition-opacity"
             >
               再試行
             </button>
@@ -77,14 +78,15 @@ export default async function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-[#0d1117] text-white">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Header */}
-      <header className="border-b border-gray-800 bg-[#0d1117]">
+      <header className="border-b border-border bg-background">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
-            <h1 className="text-xl font-semibold text-white flex items-center space-x-2">
+            <h1 className="text-xl font-semibold flex items-center space-x-2">
               <span>Linear Gantt</span>
             </h1>
+            <ThemeSelect />
           </div>
         </div>
       </header>

--- a/src/components/BulkIssueForm.tsx
+++ b/src/components/BulkIssueForm.tsx
@@ -167,18 +167,15 @@ export function BulkIssueForm({
       )}
 
       {/* Team Selector */}
-      <div className="bg-[#1c1c1e] rounded-lg border border-gray-800 p-4">
-        <label
-          htmlFor="team-select"
-          className="block text-sm font-medium text-gray-300 mb-2"
-        >
+      <div className="bg-card rounded-lg border border-border p-4">
+        <label htmlFor="team-select" className="block text-sm font-medium mb-2">
           Team *
         </label>
         <select
           id="team-select"
           value={selectedTeamId}
           onChange={(e) => setSelectedTeamId(e.target.value)}
-          className="w-full max-w-md bg-[#2c2c2e] text-white text-sm px-3 py-2 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none"
+          className="w-full max-w-md bg-card text-foreground text-sm px-3 py-2 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           required
         >
           <option value="">Select a team</option>
@@ -190,48 +187,45 @@ export function BulkIssueForm({
         </select>
       </div>
 
-      <div className="overflow-x-auto bg-[#1c1c1e] rounded-lg border border-gray-800">
+      <div className="overflow-x-auto bg-card rounded-lg border border-border">
         <table className="w-full text-xs">
-          <thead className="bg-[#2c2c2e] border-b border-gray-800">
+          <thead className="bg-primary/5 border-b border-border">
             <tr>
-              <th className="px-3 py-2 text-left font-medium text-gray-300 min-w-[180px]">
+              <th className="px-3 py-2 text-left font-medium min-w-[180px]">
                 Title *
               </th>
-              <th className="px-3 py-2 text-left font-medium text-gray-300 min-w-[350px]">
+              <th className="px-3 py-2 text-left font-medium min-w-[350px]">
                 Description
               </th>
-              <th className="px-3 py-2 text-left font-medium text-gray-300 min-w-[140px]">
+              <th className="px-3 py-2 text-left font-medium min-w-[140px]">
                 Cycle
               </th>
-              <th className="px-3 py-2 text-left font-medium text-gray-300 min-w-[100px]">
+              <th className="px-3 py-2 text-left font-medium min-w-[100px]">
                 Estimate
               </th>
-              <th className="px-3 py-2 text-left font-medium text-gray-300 min-w-[130px]">
+              <th className="px-3 py-2 text-left font-medium min-w-[130px]">
                 Due Date
               </th>
-              <th className="px-3 py-2 text-left font-medium text-gray-300 min-w-[140px]">
+              <th className="px-3 py-2 text-left font-medium min-w-[140px]">
                 Assignee
               </th>
-              <th className="px-3 py-2 text-left font-medium text-gray-300 min-w-[140px]">
+              <th className="px-3 py-2 text-left font-medium min-w-[140px]">
                 Parent Issue
               </th>
-              <th className="px-3 py-2 text-center font-medium text-gray-300 w-[50px]">
+              <th className="px-3 py-2 text-center font-medium w-[50px]">
                 削除
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-800">
+          <tbody className="divide-y divide-border">
             {rows.map((row) => (
-              <tr
-                key={row.id}
-                className="hover:bg-[#2c2c2e]/50 transition-colors"
-              >
+              <tr key={row.id} className="hover:bg-primary/5 transition-colors">
                 <td className="px-3 py-2 align-top">
                   <input
                     type="text"
                     value={row.title}
                     onChange={(e) => updateRow(row.id, "title", e.target.value)}
-                    className="w-full bg-[#2c2c2e] text-white text-xs px-2 py-1.5 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none"
+                    className="w-full bg-card text-foreground text-xs px-2 py-1.5 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                     placeholder="Issue title"
                   />
                 </td>
@@ -241,7 +235,7 @@ export function BulkIssueForm({
                     onChange={(e) =>
                       updateRow(row.id, "description", e.target.value)
                     }
-                    className="w-full bg-[#2c2c2e] text-white text-xs px-2 py-1.5 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none resize-y min-h-[60px]"
+                    className="w-full bg-card text-foreground text-xs px-2 py-1.5 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 resize-y min-h-[60px]"
                     placeholder="Optional description"
                   />
                 </td>
@@ -251,7 +245,7 @@ export function BulkIssueForm({
                     onChange={(e) =>
                       updateRow(row.id, "cycleId", e.target.value)
                     }
-                    className="w-full bg-[#2c2c2e] text-white text-xs px-2 py-1.5 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none"
+                    className="w-full bg-card text-foreground text-xs px-2 py-1.5 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                   >
                     <option value="">No Cycle</option>
                     {cycles.map((cycle) => (
@@ -267,7 +261,7 @@ export function BulkIssueForm({
                     onChange={(e) =>
                       updateRow(row.id, "estimate", e.target.value)
                     }
-                    className="w-full bg-[#2c2c2e] text-white text-xs px-2 py-1.5 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none"
+                    className="w-full bg-card text-foreground text-xs px-2 py-1.5 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                   >
                     <option value="">No Estimate</option>
                     {ESTIMATE_OPTIONS.map((value) => (
@@ -282,7 +276,7 @@ export function BulkIssueForm({
                     selected={row.dueDate}
                     onChange={(date) => updateRow(row.id, "dueDate", date)}
                     dateFormat="yyyy-MM-dd"
-                    className="w-full bg-[#2c2c2e] text-white text-xs px-2 py-1.5 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none"
+                    className="w-full bg-card text-foreground text-xs px-2 py-1.5 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                     placeholderText="Select date"
                     isClearable
                   />
@@ -293,7 +287,7 @@ export function BulkIssueForm({
                     onChange={(e) =>
                       updateRow(row.id, "assigneeId", e.target.value)
                     }
-                    className="w-full bg-[#2c2c2e] text-white text-xs px-2 py-1.5 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none"
+                    className="w-full bg-card text-foreground text-xs px-2 py-1.5 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                   >
                     <option value="">No Assignee</option>
                     {users.map((user) => (
@@ -309,7 +303,7 @@ export function BulkIssueForm({
                     onChange={(e) =>
                       updateRow(row.id, "parentId", e.target.value)
                     }
-                    className="w-full bg-[#2c2c2e] text-white text-xs px-2 py-1.5 rounded border border-gray-700 focus:border-indigo-500 focus:outline-none"
+                    className="w-full bg-card text-foreground text-xs px-2 py-1.5 rounded border border-border focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                   >
                     <option value="">No Parent</option>
                     {issues.map((issue) => (
@@ -347,7 +341,7 @@ export function BulkIssueForm({
         <button
           type="submit"
           disabled={isPending}
-          className="px-6 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center space-x-2"
+          className="px-6 py-2 bg-primary text-primary-foreground hover:opacity-80 rounded-lg transition-opacity disabled:opacity-50 disabled:cursor-not-allowed flex items-center space-x-2"
         >
           {isPending ? (
             <>

--- a/src/components/BurndownChart.tsx
+++ b/src/components/BurndownChart.tsx
@@ -239,20 +239,18 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
 
   if (issues.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64 text-gray-400 bg-gray-900 rounded-lg border border-gray-700">
+      <div className="flex items-center justify-center h-64 opacity-60 bg-card rounded-lg border border-border">
         <p>該当するIssueが見つかりません</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-900 rounded-lg shadow-lg border border-gray-700 overflow-hidden">
+    <div className="bg-card rounded-lg shadow-lg border border-border overflow-hidden">
       {/* Header */}
-      <div className="p-4 border-b border-gray-700 bg-gray-800">
-        <h3 className="text-lg font-medium text-gray-200">
-          バーンダウンチャート
-        </h3>
-        <p className="text-sm text-gray-400">
+      <div className="p-4 border-b border-border bg-card">
+        <h3 className="text-lg font-medium">バーンダウンチャート</h3>
+        <p className="text-sm opacity-60">
           総ポイント: {dataPoints[0]?.totalPlanned || 0} • 残りポイント:{" "}
           {dataPoints[dataPoints.length - 1]?.actualRemaining?.toFixed(1) || 0}{" "}
           • {selectedCycle ? "サイクル完了目標" : "Due Dateベース"}
@@ -281,8 +279,9 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
               <path
                 d="M 10 0 L 0 0 0 10"
                 fill="none"
-                stroke="#374151"
+                stroke="currentColor"
                 strokeWidth="0.5"
+                opacity="0.2"
               />
             </pattern>
           </defs>
@@ -305,14 +304,16 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
                   y1={y}
                   x2={padding.left + graphWidth}
                   y2={y}
-                  stroke="#4B5563"
+                  stroke="currentColor"
                   strokeWidth="0.5"
+                  opacity="0.2"
                 />
                 <text
                   x={padding.left - 10}
                   y={y + 4}
                   textAnchor="end"
-                  className="text-xs fill-gray-400"
+                  className="text-xs opacity-60"
+                  fill="currentColor"
                 >
                   {value.toFixed(0)}
                 </text>
@@ -331,14 +332,16 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
                     y1={padding.top}
                     x2={x}
                     y2={padding.top + graphHeight}
-                    stroke="#4B5563"
+                    stroke="currentColor"
                     strokeWidth="0.5"
+                    opacity="0.2"
                   />
                   <text
                     x={x}
                     y={padding.top + graphHeight + 20}
                     textAnchor="middle"
-                    className="text-xs fill-gray-400"
+                    className="text-xs opacity-60"
+                    fill="currentColor"
                   >
                     {formatDateShort(parseDate(d.date))}
                   </text>
@@ -371,12 +374,14 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
                 stroke="#10B981"
                 strokeWidth="2"
                 strokeDasharray="3,3"
+                opacity="0.8"
               />
               <text
                 x={scaleX(todayIndex)}
                 y={padding.top - 5}
                 textAnchor="middle"
-                className="text-xs fill-green-400 font-medium"
+                className="text-xs font-medium"
+                fill="#10B981"
               >
                 Today
               </text>
@@ -394,8 +399,9 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
                     cy={scaleY(d.plannedRemaining)}
                     r="4"
                     fill="#3B82F6"
-                    stroke="#1F2937"
+                    stroke="currentColor"
                     strokeWidth="2"
+                    opacity="0.9"
                   />
                   {/* 実際線のポイント */}
                   <circle
@@ -403,8 +409,9 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
                     cy={scaleY(d.actualRemaining)}
                     r="4"
                     fill="#EF4444"
-                    stroke="#1F2937"
+                    stroke="currentColor"
                     strokeWidth="2"
+                    opacity="0.9"
                   />
                 </g>
               );
@@ -417,7 +424,8 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
             x={chartWidth / 2}
             y={chartHeight - 10}
             textAnchor="middle"
-            className="text-sm fill-gray-300"
+            className="text-sm opacity-60"
+            fill="currentColor"
           >
             日付
           </text>
@@ -426,7 +434,8 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
             y={chartHeight / 2}
             textAnchor="middle"
             transform={`rotate(-90, 20, ${chartHeight / 2})`}
-            className="text-sm fill-gray-300"
+            className="text-sm opacity-60"
+            fill="currentColor"
           >
             残りポイント
           </text>
@@ -436,13 +445,13 @@ export function BurndownChart({ issues, selectedCycle }: BurndownChartProps) {
         <div className="flex justify-center space-x-6 mt-4">
           <div className="flex items-center space-x-2">
             <div className="w-4 h-0 border-t-2 border-dashed border-blue-400"></div>
-            <span className="text-sm text-gray-400">
+            <span className="text-sm opacity-60">
               計画線 ({selectedCycle ? "サイクル完了目標" : "Due Dateベース"})
             </span>
           </div>
           <div className="flex items-center space-x-2">
             <div className="w-4 h-0 border-t-2 border-red-400"></div>
-            <span className="text-sm text-gray-400">実績線 (完了ベース)</span>
+            <span className="text-sm opacity-60">実績線 (完了ベース)</span>
           </div>
         </div>
       </div>

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -288,17 +288,17 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
 
   if (timelineItems.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64 text-gray-400 bg-gray-900 rounded-lg border border-gray-700">
+      <div className="flex items-center justify-center h-64 opacity-60 bg-card rounded-lg border border-border">
         <p>該当するIssueが見つかりません</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-900 rounded-lg shadow-lg border border-gray-700 overflow-hidden">
+    <div className="bg-card rounded-lg shadow-lg border border-border overflow-hidden">
       {/* Date Header */}
-      <div className="flex border-b border-gray-700 bg-gray-800">
-        <div className="w-96 p-3 font-medium text-gray-200 border-r border-gray-700">
+      <div className="flex border-b border-border bg-card">
+        <div className="w-96 p-3 font-medium border-r border-border">
           Issue / Assignee
         </div>
         <div className="flex-1 relative overflow-hidden">
@@ -310,12 +310,12 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
               return (
                 <div
                   key={date.toISOString()}
-                  className={`flex-1 p-2 text-center text-xs border-r border-gray-600 ${
+                  className={`flex-1 p-2 text-center text-xs border-r border-border ${
                     isTodayCheck
-                      ? "bg-green-500/20 text-green-300 font-bold border-green-400/50"
+                      ? "bg-primary/20 font-bold border-primary/50"
                       : isWeekendCheck
-                        ? "bg-gray-700 text-gray-400"
-                        : "text-gray-300"
+                        ? "bg-primary/5 opacity-50"
+                        : ""
                   }`}
                   style={{ minWidth: `${MIN_COLUMN_WIDTH_PX}px` }}
                 >
@@ -328,7 +328,7 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
       </div>
 
       {/* Issues */}
-      <div className="divide-y divide-gray-700">
+      <div className="divide-y divide-border">
         {sortedItems.map((item) => {
           const position = getItemPosition(item);
           const assigneeColor = getAssigneeColor(item.assignee?.id);
@@ -336,9 +336,9 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
           return (
             <div
               key={item.id}
-              className="flex items-stretch hover:bg-gray-800/50 transition-colors min-h-16"
+              className="flex items-stretch hover:bg-primary/5 transition-colors min-h-16"
             >
-              <div className="w-96 p-3 border-r border-gray-700">
+              <div className="w-96 p-3 border-r border-border">
                 <div className="flex items-start space-x-2">
                   {/* Hierarchy indicator with tree lines */}
                   <div
@@ -352,11 +352,11 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
                   >
                     {item.hierarchyLevel !== undefined &&
                     item.hierarchyLevel > 0 ? (
-                      <span className="text-gray-400 text-xs font-mono">
+                      <span className="opacity-60 text-xs font-mono">
                         {HIERARCHY_SYMBOLS.CHILD_PREFIX}
                       </span>
                     ) : null}
-                    <span className="text-xs font-mono px-2 py-1 rounded flex-shrink-0 mt-0.5 text-gray-300 bg-gray-700">
+                    <span className="text-xs font-mono px-2 py-1 rounded flex-shrink-0 mt-0.5 bg-primary/10">
                       {item.identifier}
                     </span>
                   </div>
@@ -365,7 +365,7 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
                       href={`https://linear.app/issue/${item.identifier}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-sm hover:text-blue-400 hover:underline block leading-tight text-gray-100"
+                      className="text-sm hover:opacity-70 hover:underline block leading-tight"
                       title={item.title}
                     >
                       {item.title}
@@ -379,19 +379,19 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
                     {item.state.name}
                   </span>
                   {item.assignee && (
-                    <span className="text-xs text-gray-400">
+                    <span className="text-xs opacity-60">
                       • {item.assignee.displayName}
                     </span>
                   )}
                   {item.estimate && (
-                    <span className="text-xs text-blue-400 font-medium">
+                    <span className="text-xs font-medium opacity-80">
                       • {item.estimate}pt
                     </span>
                   )}
                 </div>
               </div>
 
-              <div className="flex-1 relative bg-gray-800 min-h-16 overflow-hidden">
+              <div className="flex-1 relative bg-card min-h-16 overflow-hidden">
                 {/* Date grid background */}
                 <div className="absolute inset-0 flex h-full">
                   {dateGrid.map((date) => {
@@ -401,11 +401,11 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
                     return (
                       <div
                         key={`bg-${date.toISOString()}`}
-                        className={`flex-1 border-r border-gray-600 ${
+                        className={`flex-1 border-r border-border ${
                           isTodayCheck
-                            ? "bg-green-500/10 border-green-400/30"
+                            ? "bg-primary/10 border-primary/30"
                             : isWeekendCheck
-                              ? "bg-gray-700/30"
+                              ? "bg-primary/5"
                               : ""
                         }`}
                         style={{ minWidth: `${MIN_COLUMN_WIDTH_PX}px` }}
@@ -417,7 +417,7 @@ export function GanttChart({ issues, selectedCycle }: GanttChartProps) {
                 {/* Task bar */}
                 {position.width > 0 && (
                   <div
-                    className="absolute top-4 h-8 rounded-md shadow-lg border border-gray-600/50"
+                    className="absolute top-4 h-8 rounded-md shadow-lg border border-border/50"
                     style={{
                       left: `${position.left}%`,
                       width: `${position.width}%`,

--- a/src/components/LinearWorkspace.tsx
+++ b/src/components/LinearWorkspace.tsx
@@ -96,7 +96,7 @@ export function LinearWorkspace({
   return (
     <>
       {/* Tab Navigation */}
-      <div className="border-b border-gray-800 bg-[#1c1c1e] -mx-4 px-4 mb-8">
+      <div className="border-b border-border bg-card -mx-4 px-4 mb-8">
         <div className="flex items-center justify-between mb-4">
           <div className="flex space-x-1">
             <button
@@ -104,8 +104,8 @@ export function LinearWorkspace({
               onClick={() => setActiveTab("chart")}
               className={`px-4 py-2 rounded-t-lg font-medium transition-colors ${
                 activeTab === "chart"
-                  ? "bg-[#2c2c2e] text-white border-b-2 border-indigo-500"
-                  : "text-gray-400 hover:text-white hover:bg-[#2c2c2e]/50"
+                  ? "bg-primary text-primary-foreground border-b-2 border-primary"
+                  : "opacity-60 hover:opacity-100 hover:bg-primary/10"
               }`}
             >
               チャート表示
@@ -115,8 +115,8 @@ export function LinearWorkspace({
               onClick={() => setActiveTab("bulk-create")}
               className={`px-4 py-2 rounded-t-lg font-medium transition-colors ${
                 activeTab === "bulk-create"
-                  ? "bg-[#2c2c2e] text-white border-b-2 border-indigo-500"
-                  : "text-gray-400 hover:text-white hover:bg-[#2c2c2e]/50"
+                  ? "bg-primary text-primary-foreground border-b-2 border-primary"
+                  : "opacity-60 hover:opacity-100 hover:bg-primary/10"
               }`}
             >
               Issue一括登録

--- a/src/components/SyncButton.tsx
+++ b/src/components/SyncButton.tsx
@@ -42,7 +42,7 @@ export function SyncButton({ onSync, loading, lastSync }: SyncButtonProps) {
   return (
     <div className="flex items-center space-x-4">
       {lastSync && (
-        <span className="text-sm text-gray-400">
+        <span className="text-sm opacity-60">
           最終同期: {formatLastSync(lastSync)}
         </span>
       )}
@@ -53,8 +53,8 @@ export function SyncButton({ onSync, loading, lastSync }: SyncButtonProps) {
         disabled={loading}
         className={`px-4 py-2 text-sm font-medium rounded-lg transition-all ${
           loading
-            ? "bg-gray-700 text-gray-400 cursor-not-allowed"
-            : "bg-indigo-600 text-white hover:bg-indigo-700 active:bg-indigo-800"
+            ? "bg-primary/20 opacity-50 cursor-not-allowed"
+            : "bg-primary text-primary-foreground hover:opacity-80"
         }`}
       >
         {loading ? (

--- a/src/components/ViewToggle.tsx
+++ b/src/components/ViewToggle.tsx
@@ -60,15 +60,15 @@ export function FilterControls({
     <div className="flex items-center space-x-6">
       {/* Cycle Filter */}
       <div className="flex items-center space-x-3">
-        <span className="text-sm font-medium text-gray-300 flex items-center space-x-1">
-          <Icon name="bar_chart" className="text-gray-300" />
+        <span className="text-sm font-medium flex items-center space-x-1">
+          <Icon name="bar_chart" />
           <span>Cycle:</span>
         </span>
         <select
           value={selectedCycle || ""}
           onChange={(e) => onCycleChange(e.target.value || null)}
           disabled={isLoading}
-          className="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="bg-card border border-border text-foreground text-sm rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-primary focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <option value="">すべてのCycle</option>
           {cycles.map((cycle) => (
@@ -78,8 +78,8 @@ export function FilterControls({
           ))}
         </select>
         {selectedCycleData && (
-          <span className="text-sm text-gray-400 flex items-center space-x-1">
-            <Icon name="calendar_month" className="text-gray-400" size="sm" />
+          <span className="text-sm opacity-60 flex items-center space-x-1">
+            <Icon name="calendar_month" size="sm" />
             <span>{formatCyclePeriod(selectedCycleData)}</span>
           </span>
         )}
@@ -87,15 +87,15 @@ export function FilterControls({
 
       {/* Assignee Filter */}
       <div className="flex items-center space-x-3">
-        <span className="text-sm font-medium text-gray-300 flex items-center space-x-1">
-          <Icon name="person" className="text-gray-300" />
+        <span className="text-sm font-medium flex items-center space-x-1">
+          <Icon name="person" />
           <span>Assignee:</span>
         </span>
         <select
           value={selectedAssignee || ""}
           onChange={(e) => onAssigneeChange(e.target.value || null)}
           disabled={isLoading}
-          className="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="bg-card border border-border text-foreground text-sm rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-primary focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <option value="">すべてのAssignee</option>
           <option value="unassigned">未アサイン</option>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - テーマ切替セレクターを追加。選択は即時反映され、meta theme-color 更新と合わせてブラウザ・サーバーに保存（クッキーに永続）。
  - ヘッダーにテーマセレクターを表示し、初期テーマをクッキーから復元。

- スタイル
  - アプリ全体をHSLベースのデザイントークンへ移行し、black/white のテーマを導入。
  - トップページ、フォーム、チャート、ガント、ワークスペース、同期ボタン等の配色・フォーカス・ボーダー・ホバーを統一。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->